### PR TITLE
Remove unused require of 'fs'

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 var locations = require('./locations');
 var haversine = require('haversine');
 var _ = require('lodash');


### PR DESCRIPTION
The 'fs' module is being required, but not used. That requirement was causing this package to be unusable within a [storybook](https://storybook.js.org/) context. The tests are still passing when removing 'fs' and this package now works in a storybook context.